### PR TITLE
Region support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -32,6 +32,19 @@ var metalsmith = new Metalsmith(__dirname)
   }));
 ```
 
+In case you face the following error, just add the optional parameter *region* :  
+``` TypeError: Error: PermanentRedirect: The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.```  
+
+Applicable regions are listed in [aws documentation](http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region).  
+Usage example:
+``` javascript
+.use(s3({
+  action: 'write',
+  bucket: 's3-bucket-dest',
+  region: 'eu-west-1'
+}));
+```
+
 # Actions
 ### Read
 
@@ -41,6 +54,7 @@ The _read_ action will read files from an S3 bucket which can then be processed 
 
 bucket: source S3 bucket  
 ignore: a prefix or array of prefixes _not_ to be read from the source S3 bucket  
+region: bucket's endpoint region (optional)
 
 ### Copy
 
@@ -51,6 +65,7 @@ The _copy_ action will copy files from a source S3 bucket to a destination S3 bu
 bucket: destination S3 bucket  
 from: source S3 bucket  
 prefix: a prefix or array of prefixes to be copied from the source S3 bucket  
+region: bucket's endpoint region (optional)
 
 ### Write
 
@@ -58,7 +73,8 @@ The _write_ action will write all files to the destination S3 bucket.
 
 #### Write Parameters
 
-bucket: destination S3 bucket
+bucket: destination S3 bucket  
+region: bucket's endpoint region (optional)
 
 # Credentials configuration
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,14 @@ function plugin(config) {
 		var param = {};
 
 		// initialize the API
-		var s3 = new AWS.S3();
+		var s3;
+    if(config.region){
+      s3 = new AWS.S3({
+        region: config.region
+      });
+    }else{
+      s3 = new AWS.S3();
+    }
 
         switch(config['action']) {
 		case 'copy' :


### PR DESCRIPTION
Hello,
Here is my second pull request. In order to use successfully s3, I had to add region support. Without this patch, I faced the following error.
Maybe my problem was due to my bucket being in europe while s3 api expects by default a US based bucket...
I edited README.md to reflect the changes introduced by this patch, but as I'm not a native english speaker, it may be incorrect or not very clear. Please feel free to modify it :)

/home/landry/Git/spaceinvade.rs/node_modules/aws-sdk/lib/request.js:30
            throw err;
            ^

TypeError: Error: PermanentRedirect: The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.
    at result (/home/landry/Git/spaceinvade.rs/node_modules/metalsmith-s3/lib/index.js:216:15)
    at /home/landry/Git/spaceinvade.rs/node_modules/metalsmith-s3/lib/index.js:141:11
    at /home/landry/Git/spaceinvade.rs/node_modules/metalsmith-s3/lib/index.js:210:9
    at done (/home/landry/Git/spaceinvade.rs/node_modules/async/lib/async.js:126:15)
    at Response.<anonymous> (/home/landry/Git/spaceinvade.rs/node_modules/async/lib/async.js:32:16)
    at Request.<anonymous> (/home/landry/Git/spaceinvade.rs/node_modules/aws-sdk/lib/request.js:354:18)
    at Request.callListeners (/home/landry/Git/spaceinvade.rs/node_modules/aws-sdk/lib/sequential_executor.js:105:20)
    at Request.emit (/home/landry/Git/spaceinvade.rs/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
    at Request.emit (/home/landry/Git/spaceinvade.rs/node_modules/aws-sdk/lib/request.js:596:14)
    at Request.transition (/home/landry/Git/spaceinvade.rs/node_modules/aws-sdk/lib/request.js:21:10)
    at AcceptorStateMachine.runTo (/home/landry/Git/spaceinvade.rs/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /home/landry/Git/spaceinvade.rs/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/home/landry/Git/spaceinvade.rs/node_modules/aws-sdk/lib/request.js:37:9)
    at Request.<anonymous> (/home/landry/Git/spaceinvade.rs/node_modules/aws-sdk/lib/request.js:598:12)
    at Request.callListeners (/home/landry/Git/spaceinvade.rs/node_modules/aws-sdk/lib/sequential_executor.js:115:18)
    at Request.emit (/home/landry/Git/spaceinvade.rs/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
