### PR TITLE
S3 parameter pass through

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,30 @@ var metalsmith = new Metalsmith(__dirname)
     bucket: 's3-bucket-dest'
   }));
 ```
+###S3 Library Pass Through
+You can pass through additional settings directly to the s3 library by adding an `s3` key and hash.
+Properties available vary based on the chosen action:
+  - [read](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#getObject-property)
+  - [copy](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#copyObject-property)
+  - [write](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property)
 
+Example to set the ACL for files written to s3:
+```node
+var Metalsmith = require('metalsmith');
+var s3 = require('metalsmith-s3');
+
+var metalsmith = new Metalsmith(__dirname)
+  ...
+  .use(s3({
+    action: 'write',
+    bucket: 's3-bucket-dest'
+    s3: {
+      ACL: 'public-read'
+    }
+  }));
+```
+
+###Region Override
 In case you face the following error, just add the optional parameter *region* :  
 ``` TypeError: Error: PermanentRedirect: The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.```  
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,9 @@ function plugin(config) {
 
 	return function(files, metalsmith, done) {
 		var param = {};
-
+		if (typeof config.s3 !== 'undefined'){
+			param = config.s3;
+		}
 		// initialize the API
 		var s3;
     if(config.region){


### PR DESCRIPTION
I was having trouble getting my files to be world-readable, and thought it would be nice if this plugin supported passing ACL values through to the underlying S3 library.  I added support for an `s3` key to the config hash, which becomes the base `param` object if it's defined.

I also updated the docs to explain how to use it with examples and links to the matching s3 parameter lists based on the plugin actions (read,write,copy)

Thanks for the plugin, hope this is a useful update.