### PR TITLE
Allow overriding params on a per-file basis

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ var metalsmith = new Metalsmith(__dirname)
   }));
 ```
 
+If file metadata has an `s3` key, it is mixed in as well.
+That allows overriding properties on a per-file basis.
+
+Example setting ACL for specific file in front-matter:
+```md
+---
+title: My Article
+s3:
+  ACL: private
+---
+```
+
 ### Region Override
 In case you face the following error, just add the optional parameter *region* :  
 ``` TypeError: Error: PermanentRedirect: The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.```  

--- a/lib/index.js
+++ b/lib/index.js
@@ -200,15 +200,16 @@ function plugin(config) {
 
 		function writeList(param, next) {
 			async.each(Object.keys(files), function(file, callback) {
-				param.Key = file;
-				param.Body = files[file].contents;
-				param.ContentType = (
+				var putParams = Object.assign({}, param, files[file].s3);
+				putParams.Key = file;
+				putParams.Body = files[file].contents;
+				putParams.ContentType = (
 					files[file].mimeType ||
 					mime.lookup(file) ||
 					undefined
 				)
-				debug("writing file: ", file, "with contentType = ", param.ContentType);
-				s3.putObject(param, callback);
+				debug("writing file: ", file, "with contentType = ", putParams.ContentType);
+				s3.putObject(putParams, callback);
 			}, function(err) {
 				next(err, 'write to S3 done');
 			});


### PR DESCRIPTION
I want more-efficient cache control, which includes setting different
`Cache-Control` header for different kinds of files.

Make metalsmith-s3 read file's metadata for additional params.